### PR TITLE
Add two web aliases onto cert

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     env_file:
       - .hdb-credentials
     command: >
-      --domain shiny.dide.ic.ac.uk,shiny.dide.imperial.ac.uk
+      --domain shiny.dide.ic.ac.uk,shiny.dide.imperial.ac.uk,shiny.epidemiology.net
       --email reside@imperial.ac.uk
       --dns-provider hdb
       --certificate-path /tls/certificate.pem

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,7 +55,7 @@ services:
     env_file:
       - .hdb-credentials
     command: >
-      --domain shiny.dide.ic.ac.uk
+      --domain shiny.dide.ic.ac.uk,shiny.dide.imperial.ac.uk
       --email reside@imperial.ac.uk
       --dns-provider hdb
       --certificate-path /tls/certificate.pem


### PR DESCRIPTION
This uses the latest acme-buddy (https://github.com/reside-ic/acme-buddy/pull/7) which allows comma-separated domains to be requested for the LetsEncrypt cert, so this is an easy change to allow the cert to verify all of:

shiny.dide.ic.ac.uk
shiny.dide.imperial.ac.uk
shiny.epidemiology.net
